### PR TITLE
Use raw encoding by default to handle binary files

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ function BrotliFilter(inputNode, options) {
                          options.appendSuffix :
                          true);
 
+    // Default file encoding is raw to handle binary files
+    this.inputEncoding = options.inputEncoding || null;
+    this.outputEncoding = options.outputEncoding || null;
+
     if (this.keepUncompressed && !this.appendSuffix) {
         throw new Error('Cannot keep uncompressed files without appending suffix. Filenames would be the same.');
     }


### PR DESCRIPTION
This ports a bugfix from broccoli-gzip which is supported to properly handle binary files.

See https://github.com/salsify/broccoli-gzip/commit/93c9754bfa9216a8caff67b24468c5ffe02d8872 for details.

I tested this manually by replacing `tests/fixtures/sample-assets/test.txt` with a small jpeg thumbnail. Without the fix 3/4 tests fail, with the fix all 4 tests are passing.