### PR TITLE
Restore support for iltorb compression options

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,15 @@ function BrotliFilter(inputNode, options) {
         throw new Error('Cannot keep uncompressed files without appending suffix. Filenames would be the same.');
     }
 
+    // Translate iltorb to zlib options (eg. quality -> BROTLI_PARAM_QUALITY)
+    this.brotliOptions.params = options.params || {};
+    for (var opt in options) {
+        var param = 'BROTLI_PARAM_' + opt.toUpperCase();
+        if (zlib.constants[param] !== undefined) {
+          this.brotliOptions.params[zlib.constants[param]] = options[opt];
+        }
+    }
+
     Filter.call(this, inputNode, options);
 }
 


### PR DESCRIPTION
This ensures the [iltorb compression options](https://www.npmjs.com/package/iltorb#brotliencodeparams) keep working when upgrading from `broccoli-brotli` 1.x and also makes it easier to set options, since the requirement to import zlib just to set options is no longer required.

The new params style is still supported and both can be used.

**Example:**

    options = { extensions: ['txt'], params: {
        [zlib.constants.BROTLI_PARAM_QUALITY]: 4
    }

**Becomes:**

    options = { extensions: ['txt'], quality: 4 }

----

This was discussed in https://github.com/felixbuenemann/ember-cli-brotli/pull/4, but it makes more sense to make the translation in `broccoli-brotli` instead of `ember-cli-brotli`.